### PR TITLE
Add Supabase board hook and base models

### DIFF
--- a/src/hooks/useBoards.ts
+++ b/src/hooks/useBoards.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import type { Board } from '@/types';
+
+export function useBoards(trackId: string | null) {
+  const [boards, setBoards] = useState<Board[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!trackId) {
+      setBoards([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    supabase
+      .from('boards')
+      .select('*')
+      .eq('track_id', trackId)
+      .then(({ data, error }) => {
+        if (!error && data) {
+          setBoards(data as Board[]);
+        }
+        setLoading(false);
+      });
+  }, [trackId]);
+
+  return { boards, loading };
+}
+
+export async function createBoard(
+  board: Omit<Board, 'id' | 'created_at'>,
+): Promise<Board> {
+  const { data, error } = await supabase
+    .from('boards')
+    .insert(board)
+    .single();
+  if (error || !data) throw error;
+  return data as Board;
+}
+
+export async function updateBoard(
+  id: string,
+  updates: Partial<Board>,
+): Promise<Board> {
+  const { data, error } = await supabase
+    .from('boards')
+    .update(updates)
+    .eq('id', id)
+    .single();
+  if (error || !data) throw error;
+  return data as Board;
+}
+
+export async function deleteBoard(id: string): Promise<void> {
+  const { error } = await supabase
+    .from('boards')
+    .delete()
+    .eq('id', id);
+  if (error) throw error;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,57 @@
+export type UUID = string;
+
+export type SpaceType = "private" | "team" | string;
+
+export interface User {
+  id: UUID;
+  firstname: string | null;
+  lastname: string | null;
+  avatar_url: string | null;
+  created_at: string;
+}
+
+export interface Space {
+  id: UUID;
+  created_at: string;
+  created_by: UUID;
+  name: string | null;
+  type: SpaceType;
+}
+
+export interface Track {
+  id: UUID;
+  created_at: string;
+  space_id: UUID;
+  name: string | null;
+  description: string | null;
+}
+
+export interface Board {
+  id: UUID;
+  created_at: string;
+  track_id: UUID | null;
+  title: string | null;
+  description: string | null;
+  date: string | null;
+  date_from: string | null;
+  status: "draft" | "ready" | "archived" | string | null;
+  created_by: UUID;
+}
+
+export interface Widget {
+  id: UUID;
+  created_at: string;
+  created_by: UUID;
+  title: string | null;
+  type: "kpi" | "announcement" | "question" | "help" | string;
+  status: "on_track" | "at_risk" | "fail" | null;
+  value: Record<string, any>;
+}
+
+export interface BoardWidget {
+  id: number;
+  created_at: string;
+  board_id: UUID;
+  widget_id: UUID;
+  order: number;
+}


### PR DESCRIPTION
## Summary
- define data model interfaces in `src/types.ts`
- add `useBoards` hook with CRUD helpers for boards

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684f217e839c832a8b2c7476608da9b6