### PR TITLE
Add invitation hook and claim page

### DIFF
--- a/src/hooks/useInvitationActions.ts
+++ b/src/hooks/useInvitationActions.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from "react";
+import type { Invitation } from "@/types";
+import type { PostgrestError } from "@supabase/postgrest-js";
+import { createInvitation as apiCreate, claimInvitation as apiClaim } from "@/api/invitations";
+
+interface State {
+  loading: boolean;
+  error: PostgrestError | null;
+}
+
+export function useInvitationActions() {
+  const [state, setState] = useState<State>({ loading: false, error: null });
+
+  const createInvitation = useCallback(
+    async (
+      invitation: Omit<
+        Invitation,
+        "id" | "created_at" | "token" | "status" | "accepted_by"
+      >
+    ) => {
+      setState(s => ({ ...s, loading: true, error: null }));
+      try {
+        const data = await apiCreate(invitation);
+        setState(s => ({ ...s, loading: false }));
+        return data;
+      } catch (error: any) {
+        setState({ loading: false, error });
+        throw error;
+      }
+    },
+    []
+  );
+
+  const claimInvitation = useCallback(async (token: string) => {
+    setState(s => ({ ...s, loading: true, error: null }));
+    try {
+      await apiClaim(token);
+      setState(s => ({ ...s, loading: false }));
+    } catch (error: any) {
+      setState({ loading: false, error });
+      throw error;
+    }
+  }, []);
+
+  return {
+    loading: state.loading,
+    error: state.error,
+    createInvitation,
+    claimInvitation,
+  };
+}
+

--- a/src/pages/invit.tsx
+++ b/src/pages/invit.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect } from "react";
+import type { PageProps } from "gatsby";
+import { useLocation, navigate } from "@reach/router";
+import { useInvitationActions } from "@/hooks/useInvitationActions";
+import { Spinner, Flex, Text } from "@chakra-ui/react";
+import { useSession } from "@/providers/AuthProvider";
+
+const ClaimInvitationPage: React.FC<PageProps> = () => {
+  const location = useLocation();
+  const session = useSession();
+  const { claimInvitation, loading, error } = useInvitationActions();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const token = params.get("token");
+    if (!token) return;
+    if (session === null) {
+      navigate(`/app/login?next=${encodeURIComponent(location.pathname + location.search)}`);
+      return;
+    }
+    claimInvitation(token).then(() => navigate("/app"));
+  }, [location.search, location.pathname, session, claimInvitation]);
+
+  if (loading || session === undefined) {
+    return (
+      <Flex minH="100vh" align="center" justify="center">
+        <Spinner size="xl" />
+      </Flex>
+    );
+  }
+
+  if (error) {
+    return (
+      <Flex minH="100vh" align="center" justify="center">
+        <Text color="red.500">{error.message}</Text>
+      </Flex>
+    );
+  }
+
+  return null;
+};
+
+export default ClaimInvitationPage;


### PR DESCRIPTION
## Summary
- implement `useInvitationActions` hook for creating and claiming invitations
- add `/invit` page to automatically claim invitation tokens

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6872318fa6d4832ab1ca4c82d72b146e